### PR TITLE
Fix: thrown error at invalid JSON

### DIFF
--- a/src/value.js
+++ b/src/value.js
@@ -145,9 +145,13 @@ export default class Value {
     this._storageId = Value._storages.indexOf(this._storage);
 
     // メモリ上に値がなければ storage から取り出す
-    if(typeof Value._values[this._storageId][this._key] === 'undefined') {
-      Value._values[this._storageId][this._key] = JSON.parse(this._storage.getItem(this._key));
-      Value._expires[this._storageId][this._key] = JSON.parse(this._storage.getItem(Value._expiresKeyGen(this._key)));
+    if (typeof Value._values[this._storageId][this._key] === 'undefined') {
+      try {
+        Value._values[this._storageId][this._key] = JSON.parse(this._storage.getItem(this._key));
+        Value._expires[this._storageId][this._key] = JSON.parse(this._storage.getItem(Value._expiresKeyGen(this._key)));
+      } catch (error) {
+        (console.error || console.log)('invalid value on storage-value', this._key, error);
+      }
     }
   }
 

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -1,10 +1,28 @@
 import assert from 'power-assert';
 import Value from '../src/value';
 
+const nativeConsoleError = console.error;
+let errors = [];
+
 describe('Value', () => {
+
+  before(() => {
+    // console.error() をテスト用に上書きする
+    console.error = (...args) => {
+      errors.push(args);
+    };
+  });
 
   beforeEach(() => {
     Value.clear();
+  });
+
+  afterEach(() => {
+    errors = [];
+  });
+
+  after(() => {
+    console.error = nativeConsoleError;
   });
 
   it('value に代入すると storage に保存される', () => {
@@ -151,5 +169,17 @@ describe('Value', () => {
         resolve();
       }, 600);
     });
+  });
+
+  it('invalid な値が入っている場合は無視されて console.error 出力がされる', () => {
+    // {} が閉じられていない
+    localStorage.setItem('InVaLiD', '{"foo":"var"');
+
+    const v = new Value('InVaLiD');
+    assert(v.value === null);
+    assert(errors.length === 1);
+    const error = errors[0];
+    assert(error[0] === 'invalid value on storage-value');
+    assert(error[1] === 'InVaLiD');
   });
 });


### PR DESCRIPTION
```js
console.log(localStorage.getItem('invalid'));
// "{\"invalid\":\"json\""

var v = new Value('invalid');
// SyntaxError: Unexpected end of JSON input
```

catch error and console.error().