### PR TITLE
Fix: expires が設定されていない時に gc でキーが削除される不具合

### DIFF
--- a/src/value.js
+++ b/src/value.js
@@ -34,7 +34,9 @@ export default class Value {
           return;
         }
         Value._storages[storageId].setItem(key, JSON.stringify(Value._values[storageId][key]));
-        Value._storages[storageId].setItem(Value._expiresKeyGen(key), Value._expires[storageId][key]);
+        if (Value._expires[storageId][key]) {
+          Value._storages[storageId].setItem(Value._expiresKeyGen(key), Value._expires[storageId][key]);
+        }
       });
     });
   }
@@ -78,7 +80,7 @@ export default class Value {
         }
         // 期限が切れていない場合は何もしない
         const expire = storage.getItem(expiresKey);
-        if (!expire || parseInt(expire, 10) > Date.now()) {
+        if (!expire || expire === 'null' || parseInt(expire, 10) > Date.now()) {
           return;
         }
         // 期限切れの場合は、メモリと storage から削除

--- a/src/value.js
+++ b/src/value.js
@@ -81,8 +81,8 @@ export default class Value {
           return;
         }
         // 期限が切れていない場合は何もしない
-        const expire = storage.getItem(expiresKey);
-        if (!expire || expire === 'null' || parseInt(expire, 10) > Date.now()) {
+        const expire = parseInt(storage.getItem(expiresKey), 10);
+        if (!expire || expire > Date.now()) {
           return;
         }
         // 期限切れの場合は、メモリと storage から削除

--- a/src/value.js
+++ b/src/value.js
@@ -36,6 +36,8 @@ export default class Value {
         Value._storages[storageId].setItem(key, JSON.stringify(Value._values[storageId][key]));
         if (Value._expires[storageId][key]) {
           Value._storages[storageId].setItem(Value._expiresKeyGen(key), Value._expires[storageId][key]);
+        } else {
+          Value._storages[storageId].removeItem(Value._expiresKeyGen(key));
         }
       });
     });

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -182,4 +182,18 @@ describe('Value', () => {
     assert(error[0] === 'invalid value on storage-value');
     assert(error[1] === 'InVaLiD');
   });
+
+  it('gc で expires が未指定のキーは削除しない', () => {
+    const v = new Value('test');
+    v.value = 'a';
+    return new Promise((resolve) => {
+      // 非同期で実行される flush の解決を待つ
+      setTimeout(() => {
+        assert(v.value === 'a', 'gc する前に既に削除されている');
+        Value.gc();
+        assert(v.value === 'a', 'gc によって削除されている');
+        resolve();
+      }, 600);
+    });
+  });
 });


### PR DESCRIPTION
LocalStorage に `null` をセットすると、文字列の `"null"` になる。
flush する際、expires が設定されていない場合に `null` が setItem されてしまい、次回 gc する時に `"null"` が取得され、以下の判定が false となり、 expired 扱いで削除されてしまう。

```js
if (!expire || parseInt(expire, 10) > Date.now()) {
```

`parseInt("null", 10)` は `NaN` になる。