### PR TITLE
Support IE11 on Value.gc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storage-value",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Value using Storage.",
   "main": "lib/value.js",
   "types": "lib/value.d.ts",


### PR DESCRIPTION
Currently, the `Value.gc` throws an error when the environment is IE11.

This PR aims to fix it.